### PR TITLE
Create theater company website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Современная театральная компания: премьеры, гастроли, образовательные проекты и заказ билетов онлайн.">
+    <title>Театр Сфера — современная театральная компания</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Montserrat:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script defer src="script.js"></script>
+</head>
+<body>
+    <header class="site-header" id="top">
+        <div class="container header-container">
+            <a class="brand" href="#top" aria-label="Театр Сфера">
+                <span class="brand-mark">Сфера</span>
+                <span class="brand-tagline">театр нового времени</span>
+            </a>
+            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav" aria-label="Открыть меню">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <nav id="site-nav" class="site-nav" aria-label="Основная навигация">
+                <ul>
+                    <li><a href="#productions">Репертуар</a></li>
+                    <li><a href="#about">О нас</a></li>
+                    <li><a href="#ensemble">Труппа</a></li>
+                    <li><a href="#outreach">Студия</a></li>
+                    <li><a href="#visit">Визит</a></li>
+                    <li><a class="nav-accent" href="#contact">Контакты</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero" aria-labelledby="hero-title">
+            <div class="container hero-content">
+                <div class="hero-text">
+                    <p class="hero-overtitle">Премьеры сезона 2024/25</p>
+                    <h1 id="hero-title">Живой театр, говорящий с городом</h1>
+                    <p class="hero-description">
+                        Театр «Сфера» соединяет классику и современные истории, приглашая зрителя пережить спектакль как личный опыт.
+                        На нашей сцене — громкие премьеры, камерные постановки и образовательные программы для всей семьи.
+                    </p>
+                    <div class="hero-actions">
+                        <a class="btn btn-primary" href="#productions">Афиша и билеты</a>
+                        <a class="btn btn-outline" href="#contact">Стать партнером</a>
+                    </div>
+                    <ul class="hero-highlights" aria-label="Ключевые факты о театре">
+                        <li>
+                            <strong>12</strong>
+                            <span>премьер за сезон</span>
+                        </li>
+                        <li>
+                            <strong>25+</strong>
+                            <span>актеров в труппе</span>
+                        </li>
+                        <li>
+                            <strong>4</strong>
+                            <span>лаборатории для детей и взрослых</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="hero-visual" aria-hidden="true">
+                    <div class="hero-stage">
+                        <span class="light light-left"></span>
+                        <span class="light light-right"></span>
+                        <div class="stage"></div>
+                        <div class="audience"></div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="productions" class="section" aria-labelledby="productions-title">
+            <div class="container">
+                <div class="section-header">
+                    <h2 id="productions-title">Ближайшие спектакли</h2>
+                    <p class="section-lead">Выберите постановку, забронируйте места и узнайте подробности о творческой команде.</p>
+                </div>
+                <div class="filters" role="group" aria-label="Фильтр спектаклей">
+                    <button class="filter-btn active" type="button" data-filter="all">Все</button>
+                    <button class="filter-btn" type="button" data-filter="classic">Классика</button>
+                    <button class="filter-btn" type="button" data-filter="modern">Современная драма</button>
+                    <button class="filter-btn" type="button" data-filter="family">Семейные</button>
+                </div>
+                <div class="card-grid" data-list="productions">
+                    <article class="card production-card" data-category="classic">
+                        <div class="card-header">
+                            <p class="badge">Премьера</p>
+                            <h3>«Чайка. Эскиз света»</h3>
+                        </div>
+                        <p class="card-summary">Новая интерпретация Чехова с оригинальной сценографией, где сцена превращается в кинематограф.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> 12–15 сентября</li>
+                            <li><strong>Площадка:</strong> Большая сцена</li>
+                            <li><strong>Возраст:</strong> 16+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button" data-title="Чайка. Эскиз света" data-description="Режиссёрская команда Театра «Сфера» переосмысляет классику через язык света и музыки. Спектакль исследует тему свободы, которая звучит по-новому для поколения 2020-х." data-team="Режиссёр — Полина Кравцова, художник по свету — Артём Лин, музыка — группа «Октава»" data-duration="2 часа 15 минут с антрактом">Подробнее</button>
+                        </div>
+                    </article>
+
+                    <article class="card production-card" data-category="modern">
+                        <div class="card-header">
+                            <h3>«Пульс мегаполиса»</h3>
+                        </div>
+                        <p class="card-summary">Истории жителей большого города, рассказанные через танцевальный театр и живой звук.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> 27–29 сентября</li>
+                            <li><strong>Площадка:</strong> Черный зал</li>
+                            <li><strong>Возраст:</strong> 18+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button" data-title="Пульс мегаполиса" data-description="Спектакль-погружение о жизни мегаполиса. Зрители становятся свидетелями и участниками перформативных сцен, разворачивающихся среди них." data-team="Хореография — Макс Орлов, драматургия — Мария Дудина, живой звук — электронный дуэт «Вспышка»." data-duration="1 час 40 минут без антракта">Подробнее</button>
+                        </div>
+                    </article>
+
+                    <article class="card production-card" data-category="family">
+                        <div class="card-header">
+                            <p class="badge badge-alt">Выходные</p>
+                            <h3>«Театр теней. Истории фонарщика»</h3>
+                        </div>
+                        <p class="card-summary">Музыкальная сказка с интерактивными элементами, где зрители создают собственные теневые сцены.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> Каждую субботу октября</li>
+                            <li><strong>Площадка:</strong> Камерная сцена</li>
+                            <li><strong>Возраст:</strong> 6+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button" data-title="Театр теней. Истории фонарщика" data-description="Спектакль с мастер-классом по теневому театру. Дети и родители создают персонажей и оживляют их на мини-сцене." data-team="Постановка — лаборатория «Свет и звук», автор музыки — Лада Несторова." data-duration="1 час 10 минут + мастерская">Подробнее</button>
+                        </div>
+                    </article>
+
+                    <article class="card production-card" data-category="modern">
+                        <div class="card-header">
+                            <h3>«Двенадцать этажей»</h3>
+                        </div>
+                        <p class="card-summary">Документальный проект на основе интервью с жителями многоэтажек, созданный совместно с городским архивом.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> 5–7 октября</li>
+                            <li><strong>Площадка:</strong> Лаборатория</li>
+                            <li><strong>Возраст:</strong> 14+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button" data-title="Двенадцать этажей" data-description="Вербатим-постановка, созданная по интервью с реальными жителями. Каждый этаж — отдельная история, которую зритель проживает вместе с героями." data-team="Режиссёр — Игорь Сомов, драматург — лаборатория документального театра, художник — Вера Лис." data-duration="1 час 55 минут без антракта">Подробнее</button>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="about" class="section section-alt" aria-labelledby="about-title">
+            <div class="container about-layout">
+                <div>
+                    <h2 id="about-title">Мы рассказываем истории, которые меняют взгляд</h2>
+                    <p>Театр «Сфера» — независимая команда режиссёров, артистов и продюсеров, объединённых желанием говорить о современности языком сценического искусства. Мы создаём репертуар, в котором классика встречается с актуальными темами, а традиционные формы сочетаются с новыми технологиями.</p>
+                    <ul class="checklist">
+                        <li>Авторские премьеры и международные гастроли</li>
+                        <li>Инклюзивные проекты и тактильные показы</li>
+                        <li>Открытые лаборатории для режиссёров, драматургов и композиторов</li>
+                        <li>Образовательные программы для школ и университетов</li>
+                    </ul>
+                </div>
+                <div class="about-highlight">
+                    <h3>Пространство для города</h3>
+                    <p>Наш дом — историческое здание фабрики, переосмысленное как многофункциональный театр. Здесь расположены три сцены, медиатека, кафе и репетиционные залы, открытые для жителей района.</p>
+                    <a class="btn btn-outline" href="#visit">План здания и услуги</a>
+                </div>
+            </div>
+        </section>
+
+        <section id="ensemble" class="section" aria-labelledby="ensemble-title">
+            <div class="container">
+                <div class="section-header">
+                    <h2 id="ensemble-title">Труппа и команда</h2>
+                    <p class="section-lead">Мы объединяем опытных артистов и молодых голосов театра. Познакомьтесь с лидерами творческих направлений.</p>
+                </div>
+                <div class="card-grid ensemble-grid">
+                    <article class="card person-card">
+                        <div class="person-avatar" aria-hidden="true">НД</div>
+                        <h3>Надежда Доронина</h3>
+                        <p class="person-role">художественный руководитель</p>
+                        <p>Лауреат национальной театральной премии. Куратор международной лаборатории «Диалог культур».</p>
+                        <ul class="person-links">
+                            <li><a href="mailto:doronina@sfera.theater">Написать письмо</a></li>
+                        </ul>
+                    </article>
+                    <article class="card person-card">
+                        <div class="person-avatar" aria-hidden="true">МО</div>
+                        <h3>Михаил Орлов</h3>
+                        <p class="person-role">главный режиссёр</p>
+                        <p>Известен по постановкам в Европе и Азии. Работает с перформативными практиками и иммерсивным театром.</p>
+                        <ul class="person-links">
+                            <li><a href="#productions">Постановки режиссёра</a></li>
+                        </ul>
+                    </article>
+                    <article class="card person-card">
+                        <div class="person-avatar" aria-hidden="true">АС</div>
+                        <h3>Анна Светлова</h3>
+                        <p class="person-role">директор образовательных программ</p>
+                        <p>Создаёт программы для школьников и взрослых. Руководит студиями актерского мастерства и звука.</p>
+                        <ul class="person-links">
+                            <li><a href="#outreach">Студии и курсы</a></li>
+                        </ul>
+                    </article>
+                    <article class="card person-card">
+                        <div class="person-avatar" aria-hidden="true">ЛК</div>
+                        <h3>Леонид Кравченко</h3>
+                        <p class="person-role">директор по развитию</p>
+                        <p>Отвечает за партнерства, корпоративные показы и социальные инициативы. Открыт к сотрудничеству.</p>
+                        <ul class="person-links">
+                            <li><a href="#contact">Контакт для партнёров</a></li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="calendar" class="section section-alt" aria-labelledby="calendar-title">
+            <div class="container">
+                <div class="section-header">
+                    <h2 id="calendar-title">Сезонные события</h2>
+                    <p class="section-lead">Спланируйте посещение: фестивали, читки и открытые репетиции.</p>
+                </div>
+                <div class="timeline" aria-label="Календарь событий">
+                    <article class="timeline-item">
+                        <span class="timeline-date">Август</span>
+                        <div class="timeline-content">
+                            <h3>Фестиваль новой драматургии</h3>
+                            <p>Читки пьес финалистов конкурса «Городские истории» с участием приглашённых режиссёров из Берлина и Таллина.</p>
+                        </div>
+                    </article>
+                    <article class="timeline-item">
+                        <span class="timeline-date">Октябрь</span>
+                        <div class="timeline-content">
+                            <h3>Ночь в театре</h3>
+                            <p>Иммерсивные экскурсии, behind-the-scenes показы, лекции о световом дизайне и концерты резидентов.</p>
+                        </div>
+                    </article>
+                    <article class="timeline-item">
+                        <span class="timeline-date">Декабрь</span>
+                        <div class="timeline-content">
+                            <h3>Зимняя резиденция</h3>
+                            <p>Лаборатория молодых режиссёров и художников по видео. Итог — показы эскизов на экспериментальной сцене.</p>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="outreach" class="section" aria-labelledby="outreach-title">
+            <div class="container outreach-layout">
+                <div>
+                    <h2 id="outreach-title">Образовательная студия</h2>
+                    <p class="section-lead">Раскрываем потенциал каждого: от детей до профессионалов индустрии.</p>
+                    <ul class="checklist">
+                        <li><strong>Студия «Первый выход».</strong> Актерское мастерство для подростков 12–16 лет, итогом становится совместный спектакль.</li>
+                        <li><strong>Курс «Город как сцена».</strong> Лаборатория документального театра, работа с интервью и драматургией.</li>
+                        <li><strong>Тренинг «Звук и свет».</strong> Практические занятия на профессиональном оборудовании, наставники из команды театра.</li>
+                    </ul>
+                </div>
+                <aside class="outreach-aside">
+                    <h3>Корпоративные программы</h3>
+                    <p>Мы разрабатываем team-building и образовательные форматы на основе театральных практик: сторителлинг, импровизация, публичные выступления.</p>
+                    <a class="btn btn-primary" href="#contact">Запросить предложение</a>
+                </aside>
+            </div>
+        </section>
+
+        <section id="press" class="section section-alt" aria-labelledby="press-title">
+            <div class="container press-grid">
+                <div class="section-header">
+                    <h2 id="press-title">Отзывы и пресса</h2>
+                    <p class="section-lead">О театре пишут ведущие издания и зрители, которым важен живой разговор.</p>
+                </div>
+                <div class="quote-card">
+                    <p class="quote-text">«Театр «Сфера» демонстрирует, как можно соединить классическую драматургию и мультимедийные технологии, не потеряв человеческую интонацию».</p>
+                    <p class="quote-author">— Журнал «Артикуляция»</p>
+                </div>
+                <div class="quote-card">
+                    <p class="quote-text">«После спектакля «Пульс мегаполиса» кажется, будто знаешь каждого героя лично. Театр разговаривает с городом честно и смело».</p>
+                    <p class="quote-author">— Зрительница Мария К.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="visit" class="section" aria-labelledby="visit-title">
+            <div class="container visit-layout">
+                <div>
+                    <h2 id="visit-title">Как добраться</h2>
+                    <p class="section-lead">Мы находимся в творческом кластере бывшей фабрики «Пульс» и открыты каждый день с 10:00 до 22:00.</p>
+                    <ul class="visit-info">
+                        <li><strong>Адрес:</strong> Москва, ул. Новая Сцена, 12</li>
+                        <li><strong>Метро:</strong> «Театральная площадь», выход к набережной</li>
+                        <li><strong>Паркинг:</strong> бесплатная стоянка на 50 мест, въезд с улицы Световой</li>
+                        <li><strong>Доступность:</strong> лифты, пандусы и тифлокомментарий по запросу</li>
+                    </ul>
+                    <div class="visit-cta">
+                        <a class="btn btn-outline" href="#contact">Забронировать экскурсию по театру</a>
+                    </div>
+                </div>
+                <div class="map-card" role="img" aria-label="Схема проезда к театру">
+                    <div class="map-grid">
+                        <span class="map-marker">Сфера</span>
+                    </div>
+                    <p>Мы в пяти минутах пешком от метро и рядом с городским парком. Вход через арку с неоновой вывеской.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="contact" class="section section-alt" aria-labelledby="contact-title">
+            <div class="container contact-layout">
+                <div>
+                    <h2 id="contact-title">Контакты и бронирование</h2>
+                    <p class="section-lead">Выберите удобный способ связи. Мы ответим в течение двух рабочих часов.</p>
+                    <ul class="contact-list">
+                        <li><strong>Касса:</strong> +7 (495) 000-12-12 (ежедневно 11:00–21:00)</li>
+                        <li><strong>Партнёрства:</strong> partnerships@sfera.theater</li>
+                        <li><strong>Пресса:</strong> press@sfera.theater</li>
+                        <li><strong>Адрес для писем:</strong> 109000, Москва, ул. Новая Сцена, 12</li>
+                    </ul>
+                    <div class="social-links" aria-label="Социальные сети">
+                        <a href="#" aria-label="Мы в Instagram">Instagram</a>
+                        <a href="#" aria-label="Мы во ВКонтакте">VK</a>
+                        <a href="#" aria-label="Мы в YouTube">YouTube</a>
+                    </div>
+                </div>
+                <form class="contact-form" aria-label="Форма обратной связи">
+                    <fieldset>
+                        <legend>Заявка на бронирование или сотрудничество</legend>
+                        <label>
+                            Имя и фамилия
+                            <input type="text" name="name" required placeholder="Анна Петрова">
+                        </label>
+                        <label>
+                            Электронная почта
+                            <input type="email" name="email" required placeholder="name@example.com">
+                        </label>
+                        <label>
+                            Интересующий спектакль или услуга
+                            <input type="text" name="interest" placeholder="Например, «Чайка. Эскиз света»">
+                        </label>
+                        <label>
+                            Комментарий
+                            <textarea name="message" rows="4" placeholder="Опишите запрос или количество гостей"></textarea>
+                        </label>
+                        <label class="checkbox">
+                            <input type="checkbox" name="subscribe" checked>
+                            <span>Подписаться на новости театра</span>
+                        </label>
+                        <button class="btn btn-primary" type="submit">Отправить заявку</button>
+                        <p class="form-note">Нажимая кнопку, вы соглашаетесь с политикой конфиденциальности театра.</p>
+                    </fieldset>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-container">
+            <div>
+                <a class="brand brand-footer" href="#top" aria-label="Вернуться к началу">
+                    <span class="brand-mark">Сфера</span>
+                    <span class="brand-tagline">театр нового времени</span>
+                </a>
+                <p class="footer-description">© 2024 Театр «Сфера». Независимая театральная компания. Мы благодарим зрителей и партнёров за поддержку.</p>
+            </div>
+            <div class="footer-links">
+                <a href="#productions">Афиша</a>
+                <a href="#outreach">Студия</a>
+                <a href="#contact">Политика конфиденциальности</a>
+            </div>
+            <div class="footer-meta">
+                <p>Создано с любовью к сцене и городу.</p>
+                <a class="btn btn-outline" href="mailto:hello@sfera.theater">Связаться с нами</a>
+            </div>
+        </div>
+    </footer>
+
+    <div class="modal" id="details-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+        <div class="modal-backdrop" data-dismiss="modal"></div>
+        <div class="modal-content">
+            <button class="modal-close" type="button" data-dismiss="modal" aria-label="Закрыть диалог">×</button>
+            <h3 id="modal-title"></h3>
+            <p class="modal-description"></p>
+            <p class="modal-team"></p>
+            <p class="modal-duration"></p>
+            <div class="modal-actions">
+                <a class="btn btn-primary" href="#contact">Оставить заявку</a>
+                <button class="btn btn-outline" type="button" data-dismiss="modal">Закрыть</button>
+            </div>
+        </div>
+    </div>
+
+    <noscript>
+        <div class="noscript">Для полной интерактивности сайта включите JavaScript. Основная информация доступна на странице.</div>
+    </noscript>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,122 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const navToggle = document.querySelector('.nav-toggle');
+    const siteNav = document.querySelector('#site-nav');
+
+    if (navToggle && siteNav) {
+        navToggle.addEventListener('click', () => {
+            const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+            navToggle.setAttribute('aria-expanded', String(!expanded));
+            navToggle.setAttribute('aria-label', expanded ? 'Открыть меню' : 'Закрыть меню');
+            siteNav.classList.toggle('open');
+        });
+
+        siteNav.querySelectorAll('a').forEach((link) => {
+            link.addEventListener('click', () => {
+                navToggle.setAttribute('aria-expanded', 'false');
+                navToggle.setAttribute('aria-label', 'Открыть меню');
+                siteNav.classList.remove('open');
+            });
+        });
+    }
+
+    const filterButtons = document.querySelectorAll('.filter-btn');
+    const productionCards = document.querySelectorAll('[data-list="productions"] .production-card');
+
+    const applyFilter = (category) => {
+        productionCards.forEach((card) => {
+            const match = category === 'all' || card.dataset.category === category;
+            card.hidden = !match;
+        });
+    };
+
+    filterButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            filterButtons.forEach((btn) => btn.classList.remove('active'));
+            button.classList.add('active');
+            const category = button.dataset.filter || 'all';
+            applyFilter(category);
+        });
+    });
+
+    const modal = document.getElementById('details-modal');
+    const modalTitle = modal?.querySelector('#modal-title');
+    const modalDescription = modal?.querySelector('.modal-description');
+    const modalTeam = modal?.querySelector('.modal-team');
+    const modalDuration = modal?.querySelector('.modal-duration');
+    const closeButtons = modal?.querySelectorAll('[data-dismiss="modal"]');
+    let activeTrigger = null;
+
+    const openModal = (trigger) => {
+        if (!modal || !modalTitle || !modalDescription || !modalTeam || !modalDuration) return;
+        activeTrigger = trigger;
+        modalTitle.textContent = trigger.dataset.title || 'Спектакль театра «Сфера»';
+        modalDescription.textContent = trigger.dataset.description || '';
+        modalTeam.textContent = trigger.dataset.team ? `Творческая команда: ${trigger.dataset.team}` : '';
+        modalDuration.textContent = trigger.dataset.duration ? `Продолжительность: ${trigger.dataset.duration}` : '';
+        modal.hidden = false;
+        document.body.style.overflow = 'hidden';
+        const focusable = modal.querySelector('.modal-close');
+        if (focusable) {
+            focusable.focus();
+        }
+    };
+
+    const closeModal = () => {
+        if (!modal) return;
+        modal.hidden = true;
+        document.body.style.removeProperty('overflow');
+        if (activeTrigger) {
+            activeTrigger.focus();
+            activeTrigger = null;
+        }
+    };
+
+    document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+
+        if (target.matches('.details-btn')) {
+            openModal(target);
+        }
+
+        if (target.dataset.dismiss === 'modal') {
+            closeModal();
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && modal && !modal.hidden) {
+            closeModal();
+        }
+    });
+
+    closeButtons?.forEach((btn) => {
+        btn.addEventListener('click', closeModal);
+    });
+
+    const contactForm = document.querySelector('.contact-form form, .contact-form');
+    if (contactForm instanceof HTMLFormElement) {
+        const note = contactForm.querySelector('.form-note');
+        const success = document.createElement('p');
+        success.className = 'form-success';
+        success.textContent = 'Спасибо! Мы получили вашу заявку и свяжемся с вами в ближайшее время.';
+        success.hidden = true;
+        if (note) {
+            note.insertAdjacentElement('beforebegin', success);
+        } else {
+            contactForm.append(success);
+        }
+
+        contactForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            contactForm.reset();
+            success.hidden = false;
+            if (typeof success.focus === 'function') {
+                success.focus();
+            }
+            window.setTimeout(() => {
+                success.hidden = true;
+            }, 6000);
+        });
+    }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,821 @@
+:root {
+    --color-bg: #0f1119;
+    --color-bg-alt: #161825;
+    --color-surface: rgba(255, 255, 255, 0.06);
+    --color-card: rgba(255, 255, 255, 0.08);
+    --color-accent: #ffb347;
+    --color-accent-strong: #ff8c42;
+    --color-primary: #6c63ff;
+    --color-primary-dark: #5448d6;
+    --color-text: #f3f4fa;
+    --color-muted: #c0c2d4;
+    --color-outline: rgba(255, 255, 255, 0.2);
+    --shadow-sm: 0 10px 25px rgba(0, 0, 0, 0.25);
+    --shadow-lg: 0 25px 60px rgba(0, 0, 0, 0.35);
+    --radius-sm: 12px;
+    --radius-lg: 28px;
+    --container-width: min(1080px, 92vw);
+    --transition: 0.25s ease;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at top left, rgba(108, 99, 255, 0.18), transparent 55%),
+                radial-gradient(circle at 10% 80%, rgba(255, 140, 66, 0.22), transparent 50%),
+                var(--color-bg);
+    color: var(--color-text);
+    line-height: 1.6;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    text-decoration: underline;
+}
+
+.container {
+    width: var(--container-width);
+    margin: 0 auto;
+    padding: 0 1rem;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    background: rgba(15, 17, 25, 0.92);
+    backdrop-filter: blur(12px);
+    z-index: 20;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.header-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.2rem 0;
+}
+
+.brand {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    font-family: 'Playfair Display', serif;
+}
+
+.brand-mark {
+    font-size: 1.5rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.brand-tagline {
+    font-size: 0.72rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+}
+
+.brand-footer .brand-mark {
+    font-size: 1.3rem;
+}
+
+.site-nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    padding: 0;
+}
+
+.site-nav a {
+    font-weight: 500;
+    transition: color var(--transition);
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+    color: var(--color-accent);
+}
+
+.nav-accent {
+    padding: 0.4rem 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 999px;
+}
+
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    gap: 0.3rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.nav-toggle span {
+    width: 1.75rem;
+    height: 2px;
+    background: var(--color-text);
+    transition: transform var(--transition);
+}
+
+.hero {
+    padding: 6rem 0 4rem;
+}
+
+.hero-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 3rem;
+    align-items: center;
+}
+
+.hero-overtitle {
+    text-transform: uppercase;
+    letter-spacing: 0.32em;
+    font-size: 0.72rem;
+    color: var(--color-accent);
+    margin-bottom: 1rem;
+}
+
+.hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.5rem, 5vw, 3.5rem);
+    margin: 0 0 1rem;
+}
+
+.hero-description {
+    max-width: 36rem;
+    color: var(--color-muted);
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 2rem 0 2.5rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.btn-primary {
+    background: linear-gradient(120deg, var(--color-primary), var(--color-primary-dark));
+    color: var(--color-text);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+}
+
+.btn-outline {
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: transparent;
+    color: var(--color-text);
+}
+
+.btn-outline:hover,
+.btn-outline:focus {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+.btn-ghost {
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--color-text);
+}
+
+.btn-link {
+    background: none;
+    color: var(--color-accent);
+    padding: 0;
+    font-weight: 600;
+}
+
+.btn-link:hover,
+.btn-link:focus {
+    text-decoration: underline;
+}
+
+.hero-highlights {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2.5rem;
+    padding: 0;
+    margin: 0;
+}
+
+.hero-highlights strong {
+    display: block;
+    font-size: 2rem;
+    font-family: 'Playfair Display', serif;
+}
+
+.hero-visual {
+    display: grid;
+    place-items: center;
+}
+
+.hero-stage {
+    position: relative;
+    width: min(420px, 90%);
+    aspect-ratio: 4 / 5;
+    border-radius: var(--radius-lg);
+    background: radial-gradient(circle at 50% 40%, rgba(255, 140, 66, 0.32), transparent 70%),
+                linear-gradient(160deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 2.5rem 1.75rem;
+    overflow: hidden;
+}
+
+.hero-stage .stage {
+    position: absolute;
+    inset: auto 10% 12%;
+    height: 22%;
+    background: linear-gradient(180deg, rgba(255, 179, 71, 0.7), rgba(255, 179, 71, 0.1));
+    border-radius: 60% 60% 10% 10% / 80% 80% 15% 15%;
+}
+
+.hero-stage .audience {
+    position: absolute;
+    inset: auto 5% 0;
+    height: 14%;
+    background: linear-gradient(180deg, rgba(15, 17, 25, 0), rgba(15, 17, 25, 0.85));
+}
+
+.light {
+    position: absolute;
+    top: 0;
+    width: 55%;
+    height: 55%;
+    filter: blur(6px);
+    opacity: 0.9;
+}
+
+.light-left {
+    left: -10%;
+    background: radial-gradient(circle at top, rgba(108, 99, 255, 0.55), transparent 65%);
+}
+
+.light-right {
+    right: -10%;
+    background: radial-gradient(circle at top, rgba(255, 179, 71, 0.5), transparent 65%);
+}
+
+.section {
+    padding: 4rem 0;
+}
+
+.section-alt {
+    background: rgba(255, 255, 255, 0.04);
+    backdrop-filter: blur(8px);
+}
+
+.section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-bottom: 2rem;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2rem, 4vw, 2.6rem);
+    margin: 0;
+}
+
+.section-lead {
+    color: var(--color-muted);
+    max-width: 40rem;
+}
+
+.filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+}
+
+.filter-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    background: transparent;
+    color: var(--color-muted);
+    cursor: pointer;
+    transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.filter-btn.active,
+.filter-btn:hover,
+.filter-btn:focus {
+    background: rgba(108, 99, 255, 0.24);
+    color: var(--color-text);
+    border-color: transparent;
+}
+
+.card-grid {
+    display: grid;
+    gap: 1.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.card {
+    background: var(--color-card);
+    border-radius: var(--radius-sm);
+    padding: 1.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(6px);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.card:hover,
+.card:focus-within {
+    transform: translateY(-4px);
+    border-color: rgba(255, 255, 255, 0.22);
+    box-shadow: var(--shadow-sm);
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.card h3 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+}
+
+.card-summary {
+    color: var(--color-muted);
+}
+
+.card-meta {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.card-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: auto;
+}
+
+.badge {
+    display: inline-flex;
+    align-self: flex-start;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(255, 179, 71, 0.15);
+    color: var(--color-accent);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+}
+
+.badge-alt {
+    background: rgba(108, 99, 255, 0.18);
+    color: var(--color-primary);
+}
+
+.about-layout {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+}
+
+.checklist {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.checklist li {
+    position: relative;
+    padding-left: 1.75rem;
+}
+
+.checklist li::before {
+    content: '\2713';
+    position: absolute;
+    left: 0;
+    top: 0.1rem;
+    color: var(--color-accent);
+}
+
+.about-highlight {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--shadow-sm);
+}
+
+.person-card {
+    align-items: flex-start;
+}
+
+.person-avatar {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: linear-gradient(120deg, rgba(108, 99, 255, 0.5), rgba(255, 179, 71, 0.5));
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+}
+
+.person-role {
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.75rem;
+    color: var(--color-muted);
+}
+
+.person-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    gap: 1rem;
+}
+
+.timeline {
+    display: grid;
+    gap: 2rem;
+}
+
+.timeline-item {
+    display: grid;
+    grid-template-columns: minmax(90px, 140px) 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.timeline-date {
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+}
+
+.timeline-content {
+    background: rgba(255, 255, 255, 0.05);
+    padding: 1.5rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.outreach-layout {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.outreach-aside {
+    background: rgba(255, 255, 255, 0.05);
+    padding: 2rem;
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.press-grid {
+    display: grid;
+    gap: 2rem;
+}
+
+.quote-card {
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: var(--radius-sm);
+    padding: 1.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: var(--shadow-sm);
+}
+
+.quote-text {
+    font-style: italic;
+}
+
+.visit-layout {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.visit-info {
+    list-style: none;
+    padding: 0;
+    margin: 1.75rem 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.map-card {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 2rem;
+    display: grid;
+    gap: 1.5rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.map-grid {
+    height: 220px;
+    border-radius: var(--radius-sm);
+    background: radial-gradient(circle at 20% 30%, rgba(255, 179, 71, 0.25), transparent 60%),
+                radial-gradient(circle at 80% 70%, rgba(108, 99, 255, 0.25), transparent 60%),
+                rgba(15, 17, 25, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    display: grid;
+    place-items: center;
+    position: relative;
+}
+
+.map-marker {
+    display: inline-flex;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: var(--color-primary);
+    color: #fff;
+    font-weight: 600;
+    box-shadow: var(--shadow-sm);
+}
+
+.contact-layout {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.contact-list {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.social-links {
+    display: flex;
+    gap: 1.2rem;
+    font-weight: 600;
+    margin-top: 1rem;
+}
+
+.contact-form fieldset {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-lg);
+    padding: 2rem;
+    display: grid;
+    gap: 1rem;
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.contact-form legend {
+    font-size: 1.2rem;
+    font-weight: 600;
+}
+
+.contact-form label {
+    display: grid;
+    gap: 0.4rem;
+    font-weight: 500;
+}
+
+input,
+textarea {
+    font: inherit;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(15, 17, 25, 0.55);
+    color: var(--color-text);
+    transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+input:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.25);
+}
+
+textarea {
+    resize: vertical;
+}
+
+.checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--color-muted);
+}
+
+.checkbox input {
+    width: 1rem;
+    height: 1rem;
+}
+
+.form-note {
+    font-size: 0.8rem;
+    color: var(--color-muted);
+}
+
+.form-success {
+    background: rgba(108, 99, 255, 0.18);
+    color: var(--color-text);
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(108, 99, 255, 0.35);
+    font-weight: 600;
+}
+
+.site-footer {
+    background: rgba(10, 10, 16, 0.9);
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 3rem 0;
+}
+
+.footer-container {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    align-items: start;
+}
+
+.footer-links,
+.footer-meta {
+    display: grid;
+    gap: 1rem;
+}
+
+.footer-description {
+    color: var(--color-muted);
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: 2rem;
+}
+
+.modal[hidden] {
+    display: none;
+}
+
+.modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+}
+
+.modal-content {
+    position: relative;
+    background: rgba(15, 17, 25, 0.95);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    max-width: 520px;
+    width: min(100%, 520px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: var(--shadow-lg);
+    display: grid;
+    gap: 1rem;
+}
+
+.modal-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: var(--color-muted);
+    cursor: pointer;
+}
+
+.modal-description,
+.modal-team,
+.modal-duration {
+    color: var(--color-muted);
+}
+
+.modal-actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.noscript {
+    background: #fff4d6;
+    color: #3d3200;
+    padding: 1rem;
+    text-align: center;
+    font-weight: 600;
+}
+
+@media (max-width: 900px) {
+    .site-nav {
+        position: absolute;
+        top: 100%;
+        right: 1rem;
+        background: rgba(15, 17, 25, 0.95);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: var(--radius-sm);
+        padding: 1.5rem;
+        box-shadow: var(--shadow-sm);
+        display: none;
+    }
+
+    .site-nav.open {
+        display: block;
+    }
+
+    .site-nav ul {
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .nav-toggle {
+        display: flex;
+    }
+}
+
+@media (max-width: 720px) {
+    .hero {
+        padding-top: 5rem;
+    }
+
+    .hero-highlights {
+        gap: 1.5rem;
+    }
+
+    .timeline-item {
+        grid-template-columns: 1fr;
+    }
+
+    .modal {
+        padding: 1rem;
+    }
+
+    .modal-content {
+        padding: 2rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
## Summary
- add single-page макет сайта театральной компании с героями, афишей, командой и контактами
- оформить современную визуальную тему и адаптивные сетки для ключевых секций и карточек
- подключить интерактив: мобильное меню, фильтрацию спектаклей, модальное окно и отклик формы

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d00571841083228faed964c9367d12