### PR TITLE
Rebuild AmmA Production site

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg width="320" height="160" viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">Логотип AmmA Production</title>
+  <desc id="logoDesc">Белая надпись AmmA Production на чёрном фоне с золотой плашкой художественного руководителя Веры Анненковой</desc>
+  <rect width="320" height="160" fill="#050505" rx="12"/>
+  <text x="160" y="72" text-anchor="middle" fill="#f7f4eb" font-family="'Playfair Display', 'Times New Roman', serif" font-size="58" letter-spacing="8">AmmA</text>
+  <text x="160" y="102" text-anchor="middle" fill="#f7f4eb" font-family="'Montserrat', Arial, sans-serif" font-size="20" letter-spacing="10">PRODUCTION</text>
+  <rect x="40" y="112" width="240" height="38" rx="4" fill="#caa24b"/>
+  <text x="160" y="136" text-anchor="middle" fill="#050505" font-family="'Montserrat', Arial, sans-serif" font-size="12" letter-spacing="3">ХУДОЖЕСТВЕННЫЙ РУКОВОДИТЕЛЬ ВЕРА АННЕНКОВА</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,404 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta name="description" content="AmmA Production — независимая театральная компания. Афиша спектаклей, программы, команда и контакты для партнёров и зрителей.">
+    <title>AmmA Production — независимая театральная компания</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Montserrat:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script defer src="script.js"></script>
+</head>
+<body>
+    <header class="site-header" id="top">
+        <div class="container header-container">
+            <a class="brand" href="#top" aria-label="AmmA Production">
+                <img class="brand-logo" src="assets/logo.svg" alt="Логотип AmmA Production" width="164" height="64">
+            </a>
+            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav" aria-label="Открыть меню">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <nav id="site-nav" class="site-nav" aria-label="Основная навигация">
+                <ul>
+                    <li><a href="#productions">Репертуар</a></li>
+                    <li><a href="#mission">О театре</a></li>
+                    <li><a href="#ensemble">Команда</a></li>
+                    <li><a href="#programs">Программы</a></li>
+                    <li><a href="#visit">Визит</a></li>
+                    <li><a class="nav-accent" href="#contact">Контакты</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero" aria-labelledby="hero-title">
+            <div class="container hero-container">
+                <div class="hero-copy">
+                    <p class="hero-season">Сезон 2024/25</p>
+                    <h1 id="hero-title">AmmA Production — театр, который объединяет людей и смыслы</h1>
+                    <p class="hero-lead">
+                        Мы создаём премьеры, лаборатории и городские перформансы, исследуя новые формы театра.
+                        AmmA Production — независимая творческая сила, которая приглашает зрителя быть соавтором.
+                    </p>
+                    <div class="hero-actions">
+                        <a class="btn btn-primary" href="#productions">Купить билеты</a>
+                        <a class="btn btn-outline" href="#contact">Сотрудничество</a>
+                    </div>
+                    <dl class="hero-stats">
+                        <div>
+                            <dt>12</dt>
+                            <dd>премьер в сезоне</dd>
+                        </div>
+                        <div>
+                            <dt>5</dt>
+                            <dd>образовательных программ</dd>
+                        </div>
+                        <div>
+                            <dt>30+</dt>
+                            <dd>артистов и музыкантов</dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class="hero-stage" aria-hidden="true">
+                    <div class="stage-frame">
+                        <span class="stage-light stage-light-left"></span>
+                        <span class="stage-light stage-light-right"></span>
+                        <div class="stage-curtain"></div>
+                        <div class="stage-apron"></div>
+                    </div>
+                    <p class="stage-caption">Театр, где свет и тень создают диалог</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="productions" class="section" aria-labelledby="productions-title">
+            <div class="container">
+                <header class="section-header">
+                    <h2 id="productions-title">Ближайшие спектакли</h2>
+                    <p class="section-lead">Выберите постановку AmmA Production, изучите творческую команду и бронируйте места онлайн.</p>
+                </header>
+                <div class="filters" role="group" aria-label="Фильтр спектаклей">
+                    <button class="filter-btn active" type="button" data-filter="all">Все</button>
+                    <button class="filter-btn" type="button" data-filter="premiere">Премьеры</button>
+                    <button class="filter-btn" type="button" data-filter="modern">Современная драма</button>
+                    <button class="filter-btn" type="button" data-filter="family">Для всей семьи</button>
+                </div>
+                <div class="card-grid" data-list="productions">
+                    <article class="card" data-category="premiere modern">
+                        <div class="card-head">
+                            <p class="badge">Премьера</p>
+                            <h3>«Сон об электричестве»</h3>
+                        </div>
+                        <p class="card-text">Иммерсивный спектакль о городе будущего, где свет становится языком общения между людьми.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> 14–17 сентября</li>
+                            <li><strong>Площадка:</strong> Главная сцена</li>
+                            <li><strong>Возраст:</strong> 16+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button"
+                                data-title="Сон об электричестве"
+                                data-description="AmmA Production предлагает зрителю путешествие в город будущего. Свет, звук и движение создают пространство, где можно увидеть собственные мечты."
+                                data-team="Режиссёр — Полина Кравцова, художник по свету — Артём Лин, саунд-дизайн — дуэт «Октава»"
+                                data-duration="2 часа 10 минут, антракт 20 минут">Подробнее</button>
+                        </div>
+                    </article>
+
+                    <article class="card" data-category="modern">
+                        <div class="card-head">
+                            <h3>«Пульс города»</h3>
+                        </div>
+                        <p class="card-text">Пластический спектакль о ритмах мегаполиса и людях, которые в нём живут, сочетающий живой звук и видеопроекции.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> 27–29 сентября</li>
+                            <li><strong>Площадка:</strong> Черный зал</li>
+                            <li><strong>Возраст:</strong> 18+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button"
+                                data-title="Пульс города"
+                                data-description="Интерактивный перформанс, в котором зрители становятся участниками уличного движения. Каждая сцена — новая точка на карте мегаполиса."
+                                data-team="Хореография — Макс Орлов, драматургия — Мария Дудина, электронная музыка — группа «Вспышка»"
+                                data-duration="1 час 35 минут, без антракта">Подробнее</button>
+                        </div>
+                    </article>
+
+                    <article class="card" data-category="family">
+                        <div class="card-head">
+                            <p class="badge badge-alt">Выходные</p>
+                            <h3>«Театр теней. История фонарщика»</h3>
+                        </div>
+                        <p class="card-text">Музыкальная сказка и мастерская теневого театра, где дети создают собственные сцены и персонажей.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> Каждую субботу октября</li>
+                            <li><strong>Площадка:</strong> Камерная сцена</li>
+                            <li><strong>Возраст:</strong> 6+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button"
+                                data-title="Театр теней. История фонарщика"
+                                data-description="Семейный спектакль с участием зрителей. Мы вместе оживляем городские легенды и создаём теневой спектакль прямо на сцене."
+                                data-team="Режиссёр — лаборатория «Свет и звук», композитор — Лада Несторова"
+                                data-duration="1 час 15 минут + мастер-класс">Подробнее</button>
+                        </div>
+                    </article>
+
+                    <article class="card" data-category="premiere">
+                        <div class="card-head">
+                            <p class="badge">Премьера</p>
+                            <h3>«Голос памяти»</h3>
+                        </div>
+                        <p class="card-text">Документальный спектакль по интервью с жителями дворовых сообществ — о том, как прошлое звучит сегодня.</p>
+                        <ul class="card-meta">
+                            <li><strong>Даты:</strong> 5–8 октября</li>
+                            <li><strong>Площадка:</strong> Лаборатория</li>
+                            <li><strong>Возраст:</strong> 14+</li>
+                        </ul>
+                        <div class="card-actions">
+                            <a class="btn btn-ghost" href="#contact">Забронировать</a>
+                            <button class="btn btn-link details-btn" type="button"
+                                data-title="Голос памяти"
+                                data-description="Вербатим-постановка, созданная совместно с архивистами города. Каждая история — реальный голос, который звучит на сцене AmmA Production."
+                                data-team="Режиссёр — Игорь Сомов, драматург — лаборатория документального театра, художник — Вера Лис"
+                                data-duration="1 час 55 минут, без антракта">Подробнее</button>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="mission" class="section section-alt" aria-labelledby="mission-title">
+            <div class="container two-column">
+                <div>
+                    <h2 id="mission-title">Миссия и ценности</h2>
+                    <p class="section-lead">AmmA Production исследует современный театр и строит диалог с городом, создавая события, которые меняют зрителя.</p>
+                    <ul class="checklist">
+                        <li>Работаем с актуальной драматургией, поддерживая молодых авторов.</li>
+                        <li>Запускаем лаборатории и резиденции для режиссёров и хореографов.</li>
+                        <li>Открываем театр для городских сообществ и инклюзивных проектов.</li>
+                    </ul>
+                </div>
+                <div class="mission-card">
+                    <h3>Как мы работаем</h3>
+                    <p>Мы объединяем искусство, технологии и исследования. Каждая премьера проходит путь от лаборатории до большой сцены, сохраняя живой контакт со зрителем.</p>
+                    <dl class="mission-stats">
+                        <div>
+                            <dt>4</dt>
+                            <dd>премьеры в сезон</dd>
+                        </div>
+                        <div>
+                            <dt>8</dt>
+                            <dd>городских партнёров</dd>
+                        </div>
+                        <div>
+                            <dt>1000+</dt>
+                            <dd>зрителей ежемесячно</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </section>
+
+        <section id="season" class="section" aria-labelledby="season-title">
+            <div class="container">
+                <header class="section-header">
+                    <h2 id="season-title">Сезонные события</h2>
+                    <p class="section-lead">Спецпроекты, на которые стоит обратить внимание в этом году.</p>
+                </header>
+                <div class="timeline">
+                    <article class="timeline-item">
+                        <h3>Октябрь — Фестиваль «Свет городу»</h3>
+                        <p>Четыре вечерних перформанса в городском пространстве с участием местных художников света.</p>
+                    </article>
+                    <article class="timeline-item">
+                        <h3>Ноябрь — Лаборатория драматургии</h3>
+                        <p>Двухнедельная программа для авторов, чьи тексты станут основой будущих премьер.</p>
+                    </article>
+                    <article class="timeline-item">
+                        <h3>Январь — Премьера «Нить»</h3>
+                        <p>Театр-танец о памяти поколений и семейных историях. Билеты доступны с 15 декабря.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="ensemble" class="section section-alt" aria-labelledby="ensemble-title">
+            <div class="container">
+                <header class="section-header">
+                    <h2 id="ensemble-title">Команда AmmA Production</h2>
+                    <p class="section-lead">Нас объединяет любовь к исследовательскому театру и работе с новым зрителем.</p>
+                </header>
+                <div class="card-grid trio">
+                    <article class="profile-card">
+                        <h3>Полина Кравцова</h3>
+                        <p class="profile-role">Основательница и художественный руководитель</p>
+                        <p>Режиссёр, куратор фестивалей, автор методики для лабораторий документального театра.</p>
+                    </article>
+                    <article class="profile-card">
+                        <h3>Максим Орлов</h3>
+                        <p class="profile-role">Главный хореограф</p>
+                        <p>Работает с танцевальными компаниями Европы и России, привносит в AmmA Production гибридные формы.</p>
+                    </article>
+                    <article class="profile-card">
+                        <h3>Лада Несторова</h3>
+                        <p class="profile-role">Музыкальная продюсерка</p>
+                        <p>Создаёт оригинальные партитуры, работает с живым звуком и электроникой в постановках компании.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="programs" class="section" aria-labelledby="programs-title">
+            <div class="container two-column">
+                <div>
+                    <h2 id="programs-title">Студия и образовательные программы</h2>
+                    <p class="section-lead">Мы создаём пространство, где можно исследовать театр как искусство и практику.</p>
+                    <ul class="program-list">
+                        <li>
+                            <h3>Актёрская лаборатория</h3>
+                            <p>Трёхмесячный курс для актёров и перформеров. Итог — показ новой сцены в репертуаре.</p>
+                        </li>
+                        <li>
+                            <h3>Kids Stage</h3>
+                            <p>Детская студия выходного дня, где дети создают спектакль вместе с наставниками AmmA.</p>
+                        </li>
+                        <li>
+                            <h3>Stage Design Lab</h3>
+                            <p>Практический интенсив по свету, сценографии и медиа для художников и техников.</p>
+                        </li>
+                    </ul>
+                </div>
+                <aside class="program-highlight">
+                    <h3>Присоединиться к студии</h3>
+                    <p>Оставьте заявку через форму ниже или напишите на <a href="mailto:studio@amma.productions">studio@amma.productions</a>. Мы свяжемся с вами и расскажем о ближайших наборах.</p>
+                    <a class="btn btn-primary" href="#contact">Оставить заявку</a>
+                </aside>
+            </div>
+        </section>
+
+        <section id="visit" class="section section-alt" aria-labelledby="visit-title">
+            <div class="container two-column">
+                <div>
+                    <h2 id="visit-title">План визита</h2>
+                    <p class="section-lead">Сцены AmmA Production расположены в историческом здании «Арсенал» в центре города.</p>
+                    <ul class="info-list">
+                        <li>
+                            <h3>Адрес</h3>
+                            <p>Москва, ул. Новая сцена, 8</p>
+                        </li>
+                        <li>
+                            <h3>Как добраться</h3>
+                            <p>Метро «Театральная» — 7 минут пешком. Парковка доступна на соседних улицах после 19:00.</p>
+                        </li>
+                        <li>
+                            <h3>Доступность</h3>
+                            <p>Есть пандусы, лифт и отдельные места для зрителей с инвалидностью.</p>
+                        </li>
+                    </ul>
+                </div>
+                <div class="visit-card">
+                    <h3>Касса и поддержка</h3>
+                    <p><strong>График:</strong> ежедневно с 12:00 до 20:00</p>
+                    <p><strong>Телефон:</strong> <a href="tel:+74951234567">+7 (495) 123-45-67</a></p>
+                    <p><strong>Email:</strong> <a href="mailto:tickets@amma.productions">tickets@amma.productions</a></p>
+                    <p><strong>FAQ:</strong> Билеты доступны онлайн и в кассе. Возврат — за 48 часов до спектакля.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="contact" class="section" aria-labelledby="contact-title">
+            <div class="container two-column">
+                <div>
+                    <h2 id="contact-title">Связаться с AmmA Production</h2>
+                    <p class="section-lead">Заполните форму, чтобы стать партнёром, пригласить театр или задать вопрос. Мы ответим в течение двух рабочих дней.</p>
+                    <div class="contact-details">
+                        <p><strong>Партнёрские проекты:</strong> <a href="mailto:partners@amma.productions">partners@amma.productions</a></p>
+                        <p><strong>Пресса:</strong> <a href="mailto:press@amma.productions">press@amma.productions</a></p>
+                        <p><strong>Социальные сети:</strong> <a href="https://www.instagram.com" target="_blank" rel="noreferrer">Instagram*</a>, <a href="https://t.me" target="_blank" rel="noreferrer">Telegram</a></p>
+                        <p class="contact-note">*Социальная сеть, деятельность которой запрещена на территории РФ.</p>
+                    </div>
+                </div>
+                <form class="contact-form" id="contact-form" novalidate>
+                    <div class="form-field">
+                        <label for="name">Имя</label>
+                        <input id="name" name="name" type="text" placeholder="Как к вам обращаться" required>
+                        <span class="error" id="name-error"></span>
+                    </div>
+                    <div class="form-field">
+                        <label for="email">Email</label>
+                        <input id="email" name="email" type="email" placeholder="example@domain.ru" required>
+                        <span class="error" id="email-error"></span>
+                    </div>
+                    <div class="form-field">
+                        <label for="message">Сообщение</label>
+                        <textarea id="message" name="message" rows="4" placeholder="Расскажите о вашем запросе" required></textarea>
+                        <span class="error" id="message-error"></span>
+                    </div>
+                    <button class="btn btn-primary" type="submit">Отправить</button>
+                    <p class="form-confirmation" id="form-confirmation" role="status" aria-live="polite"></p>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-container">
+            <div class="footer-brand">
+                <img src="assets/logo.svg" alt="Логотип AmmA Production" width="140" height="54">
+                <p>Независимая театральная компания AmmA Production. Мы создаём театр будущего уже сегодня.</p>
+            </div>
+            <div class="footer-links">
+                <div>
+                    <h3>Касса</h3>
+                    <p><a href="tel:+74951234567">+7 (495) 123-45-67</a></p>
+                    <p><a href="mailto:tickets@amma.productions">tickets@amma.productions</a></p>
+                </div>
+                <div>
+                    <h3>Адрес</h3>
+                    <p>Москва, ул. Новая сцена, 8</p>
+                    <p>Ежедневно с 12:00 до 20:00</p>
+                </div>
+                <div>
+                    <h3>Следите за новостями</h3>
+                    <ul>
+                        <li><a href="https://t.me" target="_blank" rel="noreferrer">Telegram</a></li>
+                        <li><a href="https://www.youtube.com" target="_blank" rel="noreferrer">YouTube</a></li>
+                        <li><a href="https://vk.com" target="_blank" rel="noreferrer">ВКонтакте</a></li>
+                    </ul>
+                </div>
+            </div>
+            <p class="footer-copy">© 2024 AmmA Production. Все права защищены.</p>
+        </div>
+    </footer>
+
+    <div class="modal" id="details-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+        <div class="modal-backdrop" data-dismiss="modal"></div>
+        <div class="modal-content">
+            <button class="modal-close" type="button" aria-label="Закрыть" data-dismiss="modal">×</button>
+            <h2 id="modal-title"></h2>
+            <p id="modal-description"></p>
+            <dl class="modal-meta">
+                <div>
+                    <dt>Команда</dt>
+                    <dd id="modal-team"></dd>
+                </div>
+                <div>
+                    <dt>Продолжительность</dt>
+                    <dd id="modal-duration"></dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,164 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const navToggle = document.querySelector('.nav-toggle');
+    const siteNav = document.querySelector('#site-nav');
+
+    if (navToggle && siteNav) {
+        navToggle.addEventListener('click', () => {
+            const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+            navToggle.setAttribute('aria-expanded', String(!expanded));
+            navToggle.setAttribute('aria-label', expanded ? 'Открыть меню' : 'Закрыть меню');
+            siteNav.classList.toggle('open');
+        });
+
+        siteNav.querySelectorAll('a').forEach((link) => {
+            link.addEventListener('click', () => {
+                navToggle.setAttribute('aria-expanded', 'false');
+                navToggle.setAttribute('aria-label', 'Открыть меню');
+                siteNav.classList.remove('open');
+            });
+        });
+    }
+
+    const filterButtons = document.querySelectorAll('.filter-btn');
+    const productionCards = document.querySelectorAll('[data-list="productions"] .card');
+
+    const applyFilter = (category) => {
+        productionCards.forEach((card) => {
+            const categories = (card.dataset.category || '').split(/\s+/).filter(Boolean);
+            const match = category === 'all' || categories.includes(category);
+            card.toggleAttribute('hidden', !match);
+        });
+    };
+
+    filterButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            filterButtons.forEach((btn) => btn.classList.remove('active'));
+            button.classList.add('active');
+            const category = button.dataset.filter || 'all';
+            applyFilter(category);
+        });
+    });
+
+    applyFilter('all');
+
+    const modal = document.getElementById('details-modal');
+    const modalTitle = modal?.querySelector('#modal-title');
+    const modalDescription = modal?.querySelector('#modal-description');
+    const modalTeam = modal?.querySelector('#modal-team');
+    const modalDuration = modal?.querySelector('#modal-duration');
+    const dismissors = modal?.querySelectorAll('[data-dismiss="modal"]');
+    let activeTrigger = null;
+
+    const openModal = (trigger) => {
+        if (!modal || !modalTitle || !modalDescription || !modalTeam || !modalDuration) return;
+        activeTrigger = trigger;
+        modalTitle.textContent = trigger.dataset.title || 'Спектакль AmmA Production';
+        modalDescription.textContent = trigger.dataset.description || '';
+        modalTeam.textContent = trigger.dataset.team || '';
+        modalDuration.textContent = trigger.dataset.duration || '';
+        modal.hidden = false;
+        document.body.style.overflow = 'hidden';
+        const closeButton = modal.querySelector('.modal-close');
+        if (closeButton) {
+            closeButton.focus();
+        }
+    };
+
+    const closeModal = () => {
+        if (!modal) return;
+        modal.hidden = true;
+        document.body.style.removeProperty('overflow');
+        if (activeTrigger) {
+            activeTrigger.focus();
+            activeTrigger = null;
+        }
+    };
+
+    document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+
+        if (target.matches('.details-btn')) {
+            event.preventDefault();
+            openModal(target);
+        }
+
+        if (target.dataset.dismiss === 'modal') {
+            closeModal();
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && modal && !modal.hidden) {
+            closeModal();
+        }
+    });
+
+    dismissors?.forEach((element) => {
+        element.addEventListener('click', closeModal);
+    });
+
+    const contactForm = document.getElementById('contact-form');
+    const confirmation = document.getElementById('form-confirmation');
+
+    if (contactForm instanceof HTMLFormElement && confirmation) {
+        const nameField = contactForm.querySelector('#name');
+        const emailField = contactForm.querySelector('#email');
+        const messageField = contactForm.querySelector('#message');
+        const nameError = contactForm.querySelector('#name-error');
+        const emailError = contactForm.querySelector('#email-error');
+        const messageError = contactForm.querySelector('#message-error');
+
+        const setError = (field, errorNode, message) => {
+            if (!(field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement) || !(errorNode instanceof HTMLElement)) {
+                return true;
+            }
+
+            if (message) {
+                errorNode.textContent = message;
+                field.setAttribute('aria-invalid', 'true');
+                return false;
+            }
+
+            errorNode.textContent = '';
+            field.removeAttribute('aria-invalid');
+            return true;
+        };
+
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+        const validateFields = () => {
+            let isValid = true;
+            isValid = setError(nameField, nameError, nameField && nameField.value.trim() ? '' : 'Укажите имя.') && isValid;
+
+            if (emailField instanceof HTMLInputElement) {
+                const value = emailField.value.trim();
+                const message = value && emailPattern.test(value) ? '' : 'Введите корректный email.';
+                isValid = setError(emailField, emailError, message) && isValid;
+            }
+
+            isValid = setError(messageField, messageError, messageField && messageField.value.trim() ? '' : 'Напишите сообщение.') && isValid;
+            return isValid;
+        };
+
+        [nameField, emailField, messageField].forEach((field) => {
+            field?.addEventListener('input', validateFields);
+            field?.addEventListener('blur', validateFields);
+        });
+
+        contactForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            if (!validateFields()) {
+                confirmation.textContent = '';
+                return;
+            }
+
+            contactForm.reset();
+            [nameField, emailField, messageField].forEach((field) => field?.removeAttribute('aria-invalid'));
+            confirmation.textContent = 'Спасибо! Мы получили сообщение и ответим в течение двух рабочих дней.';
+            window.setTimeout(() => {
+                confirmation.textContent = '';
+            }, 6000);
+        });
+    }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,856 @@
+:root {
+    --color-bg: #050505;
+    --color-surface: #111114;
+    --color-surface-alt: #16161b;
+    --color-border: rgba(255, 255, 255, 0.08);
+    --color-text: #f5f5f5;
+    --color-muted: rgba(245, 245, 245, 0.7);
+    --color-accent: #d4af37;
+    --color-accent-soft: rgba(212, 175, 55, 0.15);
+    --shadow-soft: 0 16px 40px rgba(0, 0, 0, 0.35);
+    --shadow-card: 0 20px 48px rgba(0, 0, 0, 0.45);
+    --radius-sm: 14px;
+    --radius-lg: 28px;
+    --container-max: min(1120px, 92vw);
+    --transition: 0.3s ease;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background:
+        radial-gradient(circle at 10% 15%, rgba(212, 175, 55, 0.18), transparent 55%),
+        radial-gradient(circle at 90% 20%, rgba(255, 255, 255, 0.1), transparent 45%),
+        radial-gradient(circle at 30% 80%, rgba(212, 175, 55, 0.08), transparent 60%),
+        var(--color-bg);
+    color: var(--color-text);
+    line-height: 1.6;
+    letter-spacing: 0.01em;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--color-accent);
+}
+
+.container {
+    width: var(--container-max);
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    backdrop-filter: blur(14px);
+    background: rgba(5, 5, 5, 0.85);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.header-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 0;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+}
+
+.brand-logo {
+    height: 3.25rem;
+    width: auto;
+}
+
+.site-nav ul {
+    display: flex;
+    align-items: center;
+    gap: 1.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.site-nav a {
+    font-weight: 500;
+    transition: color var(--transition);
+}
+
+.nav-accent {
+    padding: 0.4rem 0.95rem;
+    border: 1px solid rgba(212, 175, 55, 0.4);
+    border-radius: 999px;
+}
+
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.3rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(17, 17, 20, 0.75);
+    cursor: pointer;
+    transition: background var(--transition);
+}
+
+.nav-toggle span {
+    height: 2px;
+    width: 1.6rem;
+    background: var(--color-text);
+    border-radius: 999px;
+    transition: transform var(--transition);
+}
+
+.nav-toggle[aria-expanded="true"] {
+    background: rgba(212, 175, 55, 0.15);
+}
+
+.hero {
+    padding: 6.5rem 0 4rem;
+}
+
+.hero-container {
+    display: grid;
+    gap: 3.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: center;
+}
+
+.hero-season {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.32em;
+    font-size: 0.75rem;
+    color: var(--color-accent);
+    margin-bottom: 1rem;
+}
+
+.hero-season::before {
+    content: '';
+    height: 1px;
+    width: 48px;
+    background: rgba(212, 175, 55, 0.5);
+}
+
+.hero-copy h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.4rem, 5vw, 3.6rem);
+    margin: 0 0 1.25rem;
+}
+
+.hero-lead {
+    color: var(--color-muted);
+    max-width: 36rem;
+    margin-bottom: 2rem;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 2.5rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    padding: 0.85rem 1.6rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.82rem;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, #d4af37, #f4d76d);
+    color: #16161b;
+    box-shadow: 0 14px 28px rgba(212, 175, 55, 0.3);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 40px rgba(212, 175, 55, 0.35);
+}
+
+.btn-outline {
+    border-color: rgba(212, 175, 55, 0.6);
+    color: var(--color-text);
+    background: transparent;
+}
+
+.btn-outline:hover,
+.btn-outline:focus {
+    background: rgba(212, 175, 55, 0.12);
+    transform: translateY(-2px);
+}
+
+.btn-ghost {
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    padding: 0.7rem 1.4rem;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--color-text);
+    font-weight: 600;
+    font-size: 0.78rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.btn-link {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--color-accent);
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.btn-link:hover,
+.btn-link:focus {
+    text-decoration: underline;
+}
+
+.hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+    margin: 0;
+}
+
+.hero-stats dt {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.4rem;
+    color: var(--color-accent);
+}
+
+.hero-stats dd {
+    margin: 0.25rem 0 0;
+    color: var(--color-muted);
+}
+
+.hero-stage {
+    position: relative;
+    padding: 2.5rem;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(145deg, rgba(212, 175, 55, 0.05), rgba(255, 255, 255, 0));
+    border: 1px solid var(--color-border);
+    text-align: center;
+}
+
+.stage-frame {
+    position: relative;
+    border-radius: var(--radius-lg);
+    padding: 3.5rem 2.5rem 3rem;
+    background: var(--color-surface-alt);
+    box-shadow: var(--shadow-soft);
+    overflow: hidden;
+}
+
+.stage-light {
+    position: absolute;
+    top: -15%;
+    width: 160px;
+    height: 160px;
+    background: radial-gradient(circle, rgba(212, 175, 55, 0.32), transparent 70%);
+    opacity: 0.6;
+}
+
+.stage-light-left {
+    left: -10%;
+}
+
+.stage-light-right {
+    right: -10%;
+}
+
+.stage-curtain {
+    height: 160px;
+    background: linear-gradient(180deg, rgba(5, 5, 5, 0.4), rgba(5, 5, 5, 0.9));
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+}
+
+.stage-apron {
+    margin: 1.5rem auto 0;
+    width: 75%;
+    height: 16px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(212, 175, 55, 0.3), rgba(255, 255, 255, 0.08));
+}
+
+.stage-caption {
+    margin-top: 1.5rem;
+    color: var(--color-muted);
+    font-size: 0.88rem;
+}
+
+.section {
+    padding: 4.5rem 0;
+}
+
+.section-alt {
+    background: rgba(17, 17, 20, 0.7);
+    border: solid rgba(255, 255, 255, 0.04);
+    border-width: 1px 0;
+}
+
+.section-header {
+    text-align: center;
+    max-width: 48rem;
+    margin: 0 auto 3rem;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    margin-bottom: 1rem;
+}
+
+.section-lead {
+    color: var(--color-muted);
+    margin: 0;
+}
+
+.filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+    margin-bottom: 2.5rem;
+}
+
+.filter-btn {
+    padding: 0.55rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(17, 17, 20, 0.7);
+    color: var(--color-muted);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.filter-btn:hover,
+.filter-btn:focus {
+    color: var(--color-text);
+}
+
+.filter-btn.active {
+    border-color: rgba(212, 175, 55, 0.6);
+    color: var(--color-text);
+    background: rgba(212, 175, 55, 0.16);
+}
+
+.card-grid {
+    display: grid;
+    gap: 2rem;
+}
+
+.card-grid.trio {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+    background: rgba(17, 17, 20, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-lg);
+    padding: 2.2rem;
+    box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    transition: transform var(--transition), border-color var(--transition);
+}
+
+.card:hover,
+.card:focus-within {
+    transform: translateY(-6px);
+    border-color: rgba(212, 175, 55, 0.4);
+}
+
+.card-head h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.6rem;
+    margin: 0.25rem 0 0;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    background: rgba(212, 175, 55, 0.22);
+    color: var(--color-accent);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.badge-alt {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text);
+}
+
+.card-text {
+    color: var(--color-muted);
+    margin: 0;
+}
+
+.card-meta {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.4rem;
+    color: rgba(245, 245, 245, 0.7);
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.two-column {
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+}
+
+.mission-card,
+.program-highlight,
+.visit-card {
+    background: rgba(17, 17, 20, 0.82);
+    border-radius: var(--radius-lg);
+    padding: 2.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--shadow-soft);
+}
+
+.mission-card p,
+.program-highlight p,
+.visit-card p {
+    color: var(--color-muted);
+}
+
+.mission-stats,
+.mission-stats div,
+.mission-stats dt,
+.mission-stats dd {
+    margin: 0;
+}
+
+.mission-stats {
+    display: grid;
+    gap: 1.4rem;
+    margin-top: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.mission-stats dt {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.1rem;
+    color: var(--color-accent);
+}
+
+.mission-stats dd {
+    color: var(--color-muted);
+}
+
+.checklist {
+    margin: 2rem 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 1rem;
+}
+
+.checklist li {
+    display: flex;
+    gap: 0.8rem;
+    position: relative;
+    padding-left: 2rem;
+}
+
+.checklist li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.45rem;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    border: 2px solid rgba(212, 175, 55, 0.6);
+    box-shadow: inset 0 0 0 4px rgba(212, 175, 55, 0.2);
+}
+
+.timeline {
+    display: grid;
+    gap: 1.8rem;
+    position: relative;
+    padding-left: 1.5rem;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 0.35rem;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    width: 2px;
+    background: rgba(212, 175, 55, 0.35);
+}
+
+.timeline-item {
+    position: relative;
+    padding: 1.75rem 2rem;
+    background: rgba(17, 17, 20, 0.82);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--shadow-soft);
+}
+
+.timeline-item h3 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    font-family: 'Playfair Display', serif;
+}
+
+.timeline-item::before {
+    content: '';
+    position: absolute;
+    top: 1.6rem;
+    left: -1.05rem;
+    width: 0.85rem;
+    height: 0.85rem;
+    background: var(--color-accent);
+    border-radius: 50%;
+    box-shadow: 0 0 0 6px rgba(212, 175, 55, 0.2);
+}
+
+.profile-card {
+    background: rgba(17, 17, 20, 0.85);
+    border-radius: var(--radius-lg);
+    padding: 2.2rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--shadow-card);
+}
+
+.profile-role {
+    color: var(--color-accent);
+    font-weight: 600;
+    margin-top: 0.4rem;
+    margin-bottom: 1rem;
+}
+
+.program-list {
+    list-style: none;
+    margin: 2rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.program-list h3 {
+    margin-bottom: 0.4rem;
+    font-family: 'Playfair Display', serif;
+}
+
+.info-list {
+    list-style: none;
+    margin: 2rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.info-list h3 {
+    margin: 0 0 0.4rem;
+    font-family: 'Playfair Display', serif;
+}
+
+.contact-details {
+    display: grid;
+    gap: 0.8rem;
+    margin-top: 1.5rem;
+    color: var(--color-muted);
+}
+
+.contact-note {
+    font-size: 0.75rem;
+    color: rgba(245, 245, 245, 0.55);
+}
+
+.contact-form {
+    background: rgba(17, 17, 20, 0.85);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--shadow-card);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.form-field {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.form-field label {
+    font-weight: 600;
+}
+
+.form-field input,
+.form-field textarea {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(5, 5, 5, 0.6);
+    color: var(--color-text);
+    font: inherit;
+    transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+    outline: none;
+    border-color: rgba(212, 175, 55, 0.6);
+    box-shadow: 0 0 0 3px rgba(212, 175, 55, 0.12);
+}
+
+.form-field textarea {
+    resize: vertical;
+    min-height: 140px;
+}
+
+.error {
+    color: #ff8b8b;
+    font-size: 0.78rem;
+    min-height: 1rem;
+}
+
+.form-confirmation {
+    font-size: 0.9rem;
+    color: var(--color-accent);
+    min-height: 1rem;
+}
+
+.site-footer {
+    padding: 3.5rem 0 2.5rem;
+    background: rgba(5, 5, 5, 0.9);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.footer-container {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.footer-brand {
+    max-width: 28rem;
+    display: grid;
+    gap: 1rem;
+    color: var(--color-muted);
+}
+
+.footer-links {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.footer-links h3 {
+    margin: 0 0 0.75rem;
+    font-family: 'Playfair Display', serif;
+}
+
+.footer-links ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.footer-copy {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(245, 245, 245, 0.5);
+}
+
+.modal[hidden] {
+    display: none;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    z-index: 50;
+}
+
+.modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(5, 5, 5, 0.75);
+}
+
+.modal-content {
+    position: relative;
+    width: min(520px, 90vw);
+    background: rgba(17, 17, 20, 0.92);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 40px 80px rgba(0, 0, 0, 0.55);
+    display: grid;
+    gap: 1.2rem;
+}
+
+.modal-close {
+    position: absolute;
+    top: 1.2rem;
+    right: 1.2rem;
+    width: 2.4rem;
+    height: 2.4rem;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(17, 17, 20, 0.8);
+    color: var(--color-text);
+    font-size: 1.3rem;
+    cursor: pointer;
+}
+
+.modal h2 {
+    font-family: 'Playfair Display', serif;
+    margin: 0;
+}
+
+.modal-meta {
+    display: grid;
+    gap: 1rem;
+}
+
+.modal-meta div {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.modal-meta dt {
+    font-weight: 600;
+    color: var(--color-accent);
+}
+
+.modal-meta dd {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+@media (max-width: 960px) {
+    .site-nav {
+        position: fixed;
+        inset: 0 0 0 40%;
+        background: rgba(5, 5, 5, 0.96);
+        padding: 6rem 2.5rem;
+        transform: translateX(100%);
+        transition: transform var(--transition);
+    }
+
+    .site-nav.open {
+        transform: translateX(0);
+    }
+
+    .site-nav ul {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.5rem;
+    }
+
+    .nav-toggle {
+        display: inline-flex;
+    }
+}
+
+@media (max-width: 640px) {
+    .header-container {
+        padding: 1rem 0;
+    }
+
+    .hero {
+        padding-top: 5.5rem;
+    }
+
+    .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .hero-stage {
+        padding: 2rem;
+    }
+
+    .card,
+    .profile-card,
+    .timeline-item,
+    .mission-card,
+    .program-highlight,
+    .visit-card,
+    .contact-form {
+        padding: 1.8rem;
+    }
+
+    .timeline {
+        padding-left: 1rem;
+    }
+
+    .timeline::before {
+        left: 0.2rem;
+    }
+
+    .timeline-item::before {
+        left: -1.25rem;
+    }
+
+    .footer-container {
+        text-align: center;
+    }
+
+    .footer-links {
+        justify-items: center;
+    }
+}


### PR DESCRIPTION
## Summary
- rebuild the AmmA Production one-page site with refreshed hero, repertoire, mission, team, program, visit, and contact sections
- restyle the theme with a black/white/gold palette, updated cards, timelines, and responsive layouts across sections
- enhance interactivity with navigation toggling, production filtering, modal details, and contact form validation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d00571841083228faed964c9367d12